### PR TITLE
Hide mobile nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,6 +191,9 @@
       .tagline {
         font-size: 1.1rem;
       }
+      nav {
+        display: none;
+      }
       nav ul {
         flex-direction: column;
         gap: 1rem;


### PR DESCRIPTION
## Summary
- hide the navigation bar on screens 600px wide and smaller

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d7073fde083218a073ab5f912ea48